### PR TITLE
Add unique title and meta description to top-level routes

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -11,6 +11,8 @@
 
 <svelte:head>
 	<title>{errorTitle} - {siteConfig.name}</title>
+	<meta name="description" content={errorMessage} />
+	<meta name="robots" content="noindex, follow" />
 </svelte:head>
 
 <div class="container mx-auto px-4 py-16 max-w-2xl text-center">

--- a/src/routes/404/+page.svelte
+++ b/src/routes/404/+page.svelte
@@ -4,6 +4,8 @@
 
 <svelte:head>
 	<title>Page Not Found - {siteConfig.name}</title>
+	<meta name="description" content="The page you're looking for doesn't exist on {siteConfig.name}. Try the home page, blog, or contact page instead." />
+	<meta name="robots" content="noindex, follow" />
 </svelte:head>
 
 <div class="container mx-auto px-4 py-16 max-w-2xl text-center">

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,3 +1,22 @@
+<script lang="ts">
+	import { siteConfig } from '$lib/config';
+
+	const pageTitle = `About - ${siteConfig.name}`;
+	const pageDescription = `About Harun, a Canadian software developer with nearly two decades of industry experience writing about software architecture, simplicity, and craftsmanship.`;
+	const pageUrl = `${siteConfig.url}/about`;
+</script>
+
+<svelte:head>
+	<title>{pageTitle}</title>
+	<meta name="description" content={pageDescription} />
+	<link rel="canonical" href={pageUrl} />
+	<meta property="og:title" content={pageTitle} />
+	<meta property="og:description" content={pageDescription} />
+	<meta property="og:url" content={pageUrl} />
+	<meta name="twitter:title" content={pageTitle} />
+	<meta name="twitter:description" content={pageDescription} />
+</svelte:head>
+
 <div class="container mx-auto max-w-3xl px-4 py-16">
 	<h1 class="mb-10 text-4xl font-bold">About</h1>
 

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,8 +1,24 @@
 <script lang="ts">
 	import PostCard from '$lib/components/PostCard.svelte';
+	import { siteConfig } from '$lib/config';
 
 	let { data } = $props();
+
+	const pageTitle = `Blog - ${siteConfig.name}`;
+	const pageDescription = `Posts from ${siteConfig.name} on SvelteKit, FastAPI, Linux, and modern web development.`;
+	const pageUrl = `${siteConfig.url}/blog`;
 </script>
+
+<svelte:head>
+	<title>{pageTitle}</title>
+	<meta name="description" content={pageDescription} />
+	<link rel="canonical" href={pageUrl} />
+	<meta property="og:title" content={pageTitle} />
+	<meta property="og:description" content={pageDescription} />
+	<meta property="og:url" content={pageUrl} />
+	<meta name="twitter:title" content={pageTitle} />
+	<meta name="twitter:description" content={pageDescription} />
+</svelte:head>
 
 <div class="container mx-auto px-4 py-12 max-w-3xl">
 	<header class="mb-12">

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -1,12 +1,28 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { siteConfig } from '$lib/config';
 
 	let email = $state('');
 
 	onMount(() => {
 		email = ['hello', 'turtledev.io'].join('@');
 	});
+
+	const pageTitle = `Contact - ${siteConfig.name}`;
+	const pageDescription = `Get in touch with ${siteConfig.name}. Email is the best way to reach Harun for questions, feedback, or collaboration.`;
+	const pageUrl = `${siteConfig.url}/contact`;
 </script>
+
+<svelte:head>
+	<title>{pageTitle}</title>
+	<meta name="description" content={pageDescription} />
+	<link rel="canonical" href={pageUrl} />
+	<meta property="og:title" content={pageTitle} />
+	<meta property="og:description" content={pageDescription} />
+	<meta property="og:url" content={pageUrl} />
+	<meta name="twitter:title" content={pageTitle} />
+	<meta name="twitter:description" content={pageDescription} />
+</svelte:head>
 
 <div class="container mx-auto px-4 py-16 max-w-3xl">
 	<h1 class="text-4xl font-bold mb-8">Contact</h1>


### PR DESCRIPTION
Fixes Bing Webmaster Tools warnings about duplicate titles and descriptions across pages. Each route now sets its own svelte:head block that overrides the layout defaults. Adds noindex,follow to the 404 page and the +error fallback.